### PR TITLE
Restrict intersect with selected form

### DIFF
--- a/MirrorMasterDataModule.php
+++ b/MirrorMasterDataModule.php
@@ -133,7 +133,7 @@ class MirrorMasterDataModule extends \ExternalModules\AbstractExternalModule
         $sql = "select field_name from redcap_metadata a where a.project_id = " . $child_pid . $sql_child_form .
             " and field_name in (select b.field_name from redcap_metadata b where b.project_id = " . $clean_parent_pid .$sql_parent_form .  ");";
         $q = db_query($sql);
-        \Plugin::log($sql, "DEBUG", "SQL");
+//        \Plugin::log($sql, "DEBUG", "SQL");
 
         $arr_fields = array();
         while ($row = db_fetch_assoc($q)) $arr_fields[] = $row['field_name'];
@@ -236,7 +236,6 @@ class MirrorMasterDataModule extends \ExternalModules\AbstractExternalModule
         $parent_data[$pk_field] = $record_id;
         $parent_data[$config['migration-notes']] = $msg;
 
-        \Plugin::log(empty($config['master-event-name']),"config master-event-name empty? ".($config['master-event-name']));
         if (!empty($config['master-event-name'])) {
             $parent_data['redcap-event-name'] = $config['master-event-name'];
         }
@@ -268,20 +267,14 @@ class MirrorMasterDataModule extends \ExternalModules\AbstractExternalModule
      */
     public function testLogic($logic, $record) {
 
-        \Plugin::log('Testing record '. $record . ' with ' . $logic, "DEBUG");
+//      \Plugin::log('Testing record '. $record . ' with ' . $logic, "DEBUG");
         //if blank logic, then return true;
-        \Plugin::log($logic, "DEBUG", 'logic');
-        \Plugin::log(empty($logic), "DEBUG", 'EMPTY  logic');
-        \Plugin::log(isset($logic), "DEBUG", 'ISSET  logic');
-        \Plugin::log(count($logic), "DEBUG", 'COUNT  logic');
-        \Plugin::log(($logic==''), "DEBUG", 'IS LOGIC = blank');
-
         if (empty($logic)) {
             \Plugin::log("EMPTY SO RETURNING TRUE: ". empty($logic));
             return true;
         }
 
-        \Plugin::log('EVENT FOR  '. $record . ' is ' . $this->redcap_event_name, "DEBUG");
+//        \Plugin::log('EVENT FOR  '. $record . ' is ' . $this->redcap_event_name, "DEBUG");
         if (\LogicTester::isValid($logic)) {
 
             // Append current event details
@@ -362,7 +355,7 @@ class MirrorMasterDataModule extends \ExternalModules\AbstractExternalModule
         $this->record_id = $record;
         $this->instrument = $instrument;
         $this->event_id = $event_id;
-        $this->redcap_event_name = \REDCap::getEventNames(false, false, $event_id);
+        $this->redcap_event_name = \REDCap::getEventNames(true, false, $event_id);
 
 //        \Plugin::log("PROJECTID: ".$project_id . "RECORD: " . $record . " EVENT_ID: ". $event_id . " INSTRUMENT: " . $instrument . "REDCAP_EVENT_NAME " . $this->redcap_event_name);
 

--- a/config.json
+++ b/config.json
@@ -54,7 +54,7 @@
 		},
 		{
 			"key": "child-projects",
-			"name": "List of Child Projects to receieve Mirrored Data",
+			"name": "List of Child Projects to receive Mirrored Data",
 			"required": true,
 			"type": "sub_settings",
 			"repeatable":true,
@@ -67,19 +67,19 @@
 				},
 				{
 					"key": "mirror-logic",
-					"name": "Only clone if this logical expression is true (leave blank for always clone)",
+					"name": "<b>Trigger logic in Parent</b><br>Only clone if this logical expression is true (leave blank for always clone)",
 					"required": false,
 					"type": "text"
 				},
 				{
 					"key": "child-project-id",
-					"name": "Child Project",
+					"name": "<b>Child Project</b>",
 					"required": true,
 					"type": "project-id"
 				},
 				{
 					"key": "child-event-name",
-					"name": "Child Event Name (or blank if classical)",
+					"name": "<b>Child Event Name</b> (or blank if classical)",
 					"required": false,
 					"type": "custom",
 					"source": "js/config.js",
@@ -87,17 +87,29 @@
 				},
 				{
 					"key": "exclude-fields",
-					"name": "Comma-separated list of fields to exclude from copying to child project(s)",
+					"name": "<b>Excluded fields</b><br> List of fields to exclude from copying to child project(s)",
 					"required": false,
 					"type": "field-list",
 					"repeatable":true
 				},
 				{
 					"key": "include-only-fields",
-					"name": "Comma-separated list of fields to include - if specified ONLY these fields will be copied to the child project(s)",
+					"name": "<b>Include only fields</b><br> List of fields to include - if specified ONLY these fields will be copied to the child project(s)",
 					"required": false,
 					"type": "field-list",
 					"repeatable":true
+				},
+				{
+					"key": "include-only-form-child",
+					"name": "<b>Include only fields from this CHILD form</b><br>Intersection of fields from child and parent will only include child fields from this form. If left blank, it will include all child fields that intersect with parent fields.",
+					"required": false,
+					"type": "text"
+				},
+				{
+					"key": "include-only-form-parent",
+					"name": "<b>Include only fields from this PARENT form</b><br>Intersection of fields from child and parent will only include parent fields from this form. If left blank, it will include all parent fields that intersect with child fields.",
+					"required": false,
+					"type": "form-list"
 				},
 				{
 					"key": "child-field-for-parent-id",
@@ -113,25 +125,25 @@
 				},
 				{
 					"key": "child-id-prefix",
-					"name": "If this field is specified, then the child ID will be prefixed.",
+					"name": "<b>Child ID prefix</b><br>If this field is specified, then the child ID will be prefixed.",
 					"required": false,
 					"type": "text"
 				},
 				{
 					"key": "child-id-delimiter",
-					"name": "If this field is specified, then suffix and prefix will be delimited with the character.",
+					"name": "<b>Child ID delimiter</b><br>If this field is specified, then suffix and prefix will be delimited with the character.",
 					"required": false,
 					"type": "text"
 				},
 				{
 					"key": "child-id-padding",
-					"name": "If this field is specified, then the unique ID of the child ID will be padded with zeros to this number of characters. For example, a padding of 4 will result in an id:STAN-0004",
+					"name": "<b>Child ID padding</b><br>If this field is specified, then the unique ID of the child ID will be padded with zeros to this number of characters. For example, a padding of 4 will result in an id:STAN-0004",
 					"required": false,
 					"type": "text"
 				},
 				{
 					"key": "child-field-clobber",
-					"name": "If this field is checked, then if there is existing data in the child project for that field, the data will be clobbered.",
+					"name": "<b>Clobber existing data</b><br>If this field is checked, then if there is existing data in the child project for that field, the data will be clobbered.",
 					"required": false,
 					"type": "checkbox"
 				},


### PR DESCRIPTION
Add option to specify forms to send fields and to receive fields.
Intersection of fields from parent and child project can be 
restricted to forms.